### PR TITLE
docker コマンド周りの改修

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,4 @@
 requires 'perl', '5.008001';
-requires 'Guard';
 requires 'DBI';
 requires 'DBD::Pg';
 requires 'Sub::Retry';

--- a/lib/Test/PostgreSQL/Docker.pm
+++ b/lib/Test/PostgreSQL/Docker.pm
@@ -186,7 +186,9 @@ sub port {
 
 sub container_name {
     my ($self) = @_;
-    sprintf "%s-%s-%s", $self->{pgname}, $self->{tag}, $self->oid;
+    my $pgname = $self->{pgname};
+    $pgname =~ s/[^a-zA-Z0-9_.-]/__/g;
+    sprintf "%s-%s-%s", $pgname, $self->{tag}, $self->oid;
 }
 
 sub image_name {

--- a/lib/Test/PostgreSQL/Docker.pm
+++ b/lib/Test/PostgreSQL/Docker.pm
@@ -239,7 +239,7 @@ Test::PostgreSQL::Docker - A Postgresql mock server for testing perl programs
 
 Test::PostgreSQL::Docker run the postgres container on the Docker, for testing your perl programs.
 
-B<**NOTE**> Maybe this module doesn't work on the Windows, because this module uses some backticks for use the Docker.
+B<**NOTE**> Maybe this module doesn't work on the Windows, because we don't any test on Windows machine.
 
 
 =head1 METHODS
@@ -249,6 +249,10 @@ B<**NOTE**> Maybe this module doesn't work on the Windows, because this module u
     $server = Test::PostgreSQL::Docker->new(%opt)
 
 =over 2
+
+=item docker (str)
+
+The path to C<docker>. Default is C</usr/bin/docker>.
 
 =item pgname (str)
 
@@ -273,6 +277,10 @@ Default is C<postgres>.
 =item dbname (str)
 
 Default is C<test>.
+
+=item print_docker_error (bool)
+
+Show docker error. Default is C<true value>.
 
 =back
 
@@ -346,12 +354,26 @@ Default is C<sprintf('-h %s -p %s -U %s -d %s', $self->{host}, 5432, $self->{dbo
 
     $server = $server->run_psql(@args)
 
-    $server->run_psql('-c', q|"INSERT INTO foo (bar) VALUES ('baz')"|);
+    $server->run_psql('-c', q|INSERT INTO foo (bar) VALUES ('baz')|);
 
 
 =head2 run_psql_scripts
 
     $server = $server->run_psql_scripts($path)
+
+
+=head2 docker_is_running
+
+    $server = $server->docker_is_running()
+
+Return true if docker container is running.
+
+
+=head2 docker_daemon_is_accessible
+
+    $server = $server->docker_daemon_is_accessible()
+
+Return true if docker daemon is accessible.
 
 
 =head1 REQUIREMENT
@@ -377,6 +399,7 @@ Satoshi Azuma E<lt>ytnobody@gmail.comE<gt>
 
 =head1 SEE ALSO
 
+L<Test::PostgreSQL>
 L<https://hub.docker.com/_/postgres>
 
 =cut

--- a/t/01_no_docker.t
+++ b/t/01_no_docker.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use lib qw(t/lib);
+use Test::More;
+use t::Util;
+use File::Spec;
+
+my $server = Test::PostgreSQL::Docker->new( t::Util::default_args_for_new(), docker => './ese_docker' );
+is $server->docker, './ese_docker';
+
+ok !$server->docker_daemon_is_accessible();
+ok !$server->docker_is_running();
+
+is $server->run(), $server;
+
+
+done_testing;

--- a/t/10_run.t
+++ b/t/10_run.t
@@ -1,13 +1,20 @@
 use strict;
 use warnings;
+use lib qw(t/lib);
 use Test::More;
-use Test::PostgreSQL::Docker;
+use t::Util;
 use File::Spec;
 
-my $server = Test::PostgreSQL::Docker->new(tag => '12-alpine');
-isa_ok($server, 'Test::PostgreSQL::Docker');
-can_ok($server, qw/pull run psql_args run_psql run_psql_scripts oid dbh dsn container_name image_name/);
+my $server = t::Util->new_server();
 
+unless ( $server->docker_is_running ) {
+    plan skip_all => "docker is not running.";
+    exit;
+}
+
+isa_ok($server, 'Test::PostgreSQL::Docker');
+can_ok($server, qw/pull run psql_args run_psql run_psql_scripts oid dbh dsn container_name image_name
+                                docker docker_daemon_is_accessible docker_is_running/);
 my $fixture_file = File::Spec->catfile(qw/t data fixture.sql/);
 
 my $dbh = $server
@@ -27,7 +34,8 @@ is_deeply($res, {'1' => {
     'password' => 'hogehoge'
 }});
 
-$server->run_psql('-c', q|"INSERT INTO users (account_name, password) VALUES ('foo','bar')"|);
+$server->run_psql('-c', q|INSERT INTO users (account_name, password) VALUES ('foo','bar')|);
+#$server->run_psql('-c', q|"INSERT INTO users (account_name, password) VALUES ('foo','bar')"|);
 
 $res = $dbh->selectrow_hashref(q/SELECT * FROM users WHERE account_name = 'foo'/);
 is_deeply($res, {

--- a/t/11_options.t
+++ b/t/11_options.t
@@ -1,22 +1,25 @@
 use strict;
 use warnings;
+use lib qw(t/lib);
 use Test::More;
-use Test::PostgreSQL::Docker;
+use t::Util;
 
 my %opt = (
-    tag    => '12-alpine',
     dbname => 'testdb',
-    user   => 'foobar',
+    dbowner=> 'foobar',
 );
 
-my $server = Test::PostgreSQL::Docker->new(%opt);
+my $server = t::Util->new_server(%opt);
 
-ok $server->run(), "server is runing";
+unless ( $server->docker_is_running ) {
+    plan skip_all => "docker is not running.";
+    exit;
+}
 
 my $dsn = $server->dsn;
 
 
-is $server->{user}, 'foobar';
+is $server->{dbowner}, 'foobar';
 like $dsn, qr/dbname=testdb/;
 
 

--- a/t/12_duplicated_run.t
+++ b/t/12_duplicated_run.t
@@ -1,21 +1,22 @@
 use strict;
 use warnings;
+use lib qw(t/lib);
 use Test::More;
-use Test::PostgreSQL::Docker;
+use t::Util;
 
-my %opt = (
-    tag    => '12-alpine',
-);
 
-my $server1 = Test::PostgreSQL::Docker->new(%opt);
+my $server1 = t::Util->new_server();
 
-ok $server1->run(), "server1 is runing";
+unless ( $server1->docker_is_running ) {
+    plan skip_all => "docker is not running.";
+    exit;
+}
 
 my $dsn1 = $server1->dsn;
 my $dbh1 = DBI->connect($server1->dsn(dbname => 'template1'), '', '', {});
 ok $dbh1, 'create dbh by DBI';
 
-my $server2 = Test::PostgreSQL::Docker->new(%opt);
+my $server2 = Test::PostgreSQL::Docker->new( t::Util->default_args_for_new );
 
 ok $server2->run(), "server2 is runing";
 

--- a/t/lib/t/Util.pm
+++ b/t/lib/t/Util.pm
@@ -1,0 +1,60 @@
+package t::Util;
+
+use strict;
+use warnings;
+use Test::PostgreSQL::Docker;
+use Data::Dumper;
+
+my $REP = $ENV{PERL_TEST_PG_DOCKER_REP} || 'postgres';
+my $TAG = $ENV{PERL_TEST_PG_DOCKER_REP} || '12-alpine';
+
+sub default_args_for_new {
+    return (pgname => $REP, tag => $TAG);
+}
+
+sub new_server {
+    my ( $class, %opt ) = @_;
+    my $obj;
+
+    if ( my $json = $ENV{__PERL_TEST_PG_DOCKER} ) {
+        eval { require JSON::PP; 1 };
+        $obj = JSON::PP::decode_json($json);
+    }
+
+    my $server;
+    my %name = (dbowner => 'postgres', dbname => 'test', %opt);
+    my $name = join(':', map { $name{$_} } sort qw/dbowner dbname/ );
+
+    if ($obj && $obj->{$name}) {
+        return bless { %{$obj->{$name}} }, 'Test::PostgreSQL::Docker';
+    }
+
+    $server = Test::PostgreSQL::Docker->new(default_args_for_new(), %opt);
+
+    return $server->run(skip_pull => 1);
+}
+
+
+# PERL5LIB=./lib:./t/lib prove -I./lib -Pt::Util t
+
+sub load {
+    eval { require JSON::PP; 1 } or return;
+    my $env = $ENV{__PERL_TEST_PG_DOCKER};
+
+    our $loaded_server  = t::Util->new_server();
+
+    print STDERR $@;
+
+    $env = $env ? JSON::PP::decode_json($env) : {};
+
+    my $name = join(':', @{$loaded_server}{sort qw/dbowner dbname/} );
+
+    $ENV{__PERL_TEST_PG_DOCKER} = JSON::PP::encode_json( {
+        %$env, $name => {
+            map { $_ => $loaded_server->{$_} } qw/docker pgname tag oid dbowner password dbname port host print_docker_error docker_is_running _orig_address/
+        }
+    }) if $loaded_server;
+}
+
+
+1;


### PR DESCRIPTION
* backtick をやめて IPC::Run を利用（Windwosでも動くかも）
  * run_psql や run_psql_scripts もそれにあわせて修正
* guard をやめて DESTROY メソッドで後処理させる
* docker が動いていないときはテストをスキップ
* PERL5LIB=./lib:./t/lib prove -I./lib -Pt::Util t で高速化

大きく分けて上記4点に関する修正を行いました。